### PR TITLE
feat: PRO-1622: Create parameter store value if one doesn't exist

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: Local-Action-Test
 
 on:
   push:
-    branches: [master]
+    branches: [master, feat-pro-1622]
 
 jobs:
   test:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,14 @@ jobs:
           ssm-path: /actions-testing/test-parameter-basic
           decryption: false
           nullable: true
+      
+      - name: Test creating ssm value
+        uses: ./
+        id: new-ssm-value
+        with:
+            ssm-path: /actions-testing/test-new-parameter
+            ssm-value: "test string value"
+            ssm-value-type: String
 
       - name: Test for Env Variables
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: Local-Action-Test
 
 on:
   push:
-    branches: [master, feat-pro-1622]
+    branches: [master]
 
 jobs:
   test:
@@ -39,14 +39,6 @@ jobs:
           ssm-path: /actions-testing/test-parameter-basic
           decryption: false
           nullable: true
-      
-      - name: Test creating ssm value
-        uses: ./
-        id: new-ssm-value
-        with:
-            ssm-path: /actions-testing/test-new-parameter
-            ssm-value: "test string value"
-            ssm-value-type: String
 
       - name: Test for Env Variables
         run: |

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ variables in this action's step.
 
 ## Usage:
 
+To pull value from existing object
+
 ```yaml
 - uses: Produce8/actions-aws-ssm-params-to-env@v1.2
   env:
@@ -20,6 +22,24 @@ variables in this action's step.
     nullable: false # optional, default false
 ```
 
+To pull value if paramter store value exists, or create a parameter store entry with a given value if one doesn't exist:
+
+```yaml
+- uses: Produce8/actions-aws-ssm-params-to-env@v1.2
+  env:
+    AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }} # required
+    AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }} # required
+    AWS_DEFAULT_REGION: ap-northeast-2 # required
+  with:
+    ssm-path: /path/to/parameter # required
+    ssm-value: # optional (but necessary for creating new paramater store value)
+    ssm-value-type # optional (but necessary for creating new paramater store value)
+    prefix: SSM_ # optional
+    json-as-string # optional, default false
+    decryption: true # optional, default false
+    nullable: false # optional, default false
+```
+
 ---
 
 ## Options:
@@ -28,6 +48,14 @@ variables in this action's step.
 
 AWS Systems Manager Parameter Store path to the parameter
 (e.g. `/path/to/parameter`)
+
+### ssm-value(optional)
+
+String, StringList or SecureString value to write to a new Parmeter Store path if it does not exist
+
+### ssm-value-type(optional)
+
+String, StringList or SecureString
 
 ### prefix(optional)
 
@@ -47,6 +75,10 @@ the value of such parameters from your logs.
 
 Boolean which indicates whether the parameter needs to exist
 
+### json-as-string(optional)
+
+Boolean which - when true - overwrites default behavior of parsing JSON objects into separate environment variables
+
 ---
 
 ## Example output:
@@ -65,6 +97,19 @@ If you have an ssm parameter path of `/application/staging/parameter` with the f
 the action will set environment variables for you for each key/value pair of the JSON.
 `$APPLICATION_URL` will be set to `https://api.com` and
 `$DB_NAME` will be set to `somedbname`.
+
+### JSON data as a string value
+
+To avoid the default behavior of setting JSON data as inidivdual environment variables, and instead keep a stringified JSON object a string, use the json-as-string parameter with a value of true.
+
+If you have an ssm parameter path of `/application/staging/parameter` with the value:
+
+```
+"{\n  \"APPLICATION_URL\": \"https://api.com\",\n  \"DB_NAME\": \"somedbname\"\n}"
+```
+
+the action will set an environment variable for you such that `echo $parameter`
+will output an unmodified version of the JSON string.
 
 ### String data
 

--- a/action.yml
+++ b/action.yml
@@ -17,11 +17,17 @@ inputs:
   prefix:
     description: "Set a prefix on the environment variable"
     required: false
+  key-name:
+    description: "Set a key name on the parameter store variable"
+    required: false
   decryption:
     description: "Whether the parameter must be decrypted or not"
     required: false
   nullable:
     description: "Whether the parameter must exist or not"
+    required: false
+  json-as-string:
+    description: "Pass JSON object as a string"
     required: false
 runs:
   using: "node12"

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,12 @@ inputs:
   ssm-path:
     description: "AWS SSM path for parameter (eg. `/ssm/parameter`)"
     required: true
+  ssm-value:
+    description: "AWS SSM value to create new parameter"
+    required: false
+  ssm-value-type:
+    description: "AWS SSM parameter type: String, StringList or SecureString"
+    required: false
   prefix:
     description: "Set a prefix on the environment variable"
     required: false

--- a/action.yml
+++ b/action.yml
@@ -17,9 +17,6 @@ inputs:
   prefix:
     description: "Set a prefix on the environment variable"
     required: false
-  key-name:
-    description: "Set a key name on the parameter store variable"
-    required: false
   decryption:
     description: "Whether the parameter must be decrypted or not"
     required: false

--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ function setEnvironmentVar(key, value) {
 function jsonOrString(paramValue, core, prefix, ssmPath, jsonAsString) {
   const parsedValue = parseValue(paramValue);
   if (jsonAsString) {
-    const envVarName = prefix + split[split.length - 1];
+    const envVarName = getEnvName(ssmPath, prefix);
     core.debug(`Using prefix + end of ssmPath for env var name: ${envVarName}`);
     return setEnvironmentVar(envVarName, paramValue);
   }
@@ -63,11 +63,15 @@ function jsonOrString(paramValue, core, prefix, ssmPath, jsonAsString) {
   } else {
     core.debug(`parsedValue: ${parsedValue}`);
     // Set environment variable with ssmPath name as the env variable
-    const split = ssmPath.split("/");
-    const envVarName = prefix + split[split.length - 1];
+    const envVarName = getEnvName(ssmPath, prefix);
     core.debug(`Using prefix + end of ssmPath for env var name: ${envVarName}`);
     return setEnvironmentVar(envVarName, parsedValue);
   }
+}
+
+function getEnvName(path, prefix) {
+  const split = path.split("/");
+  return prefix + split[split.length - 1];
 }
 
 run_action();

--- a/index.js
+++ b/index.js
@@ -8,19 +8,21 @@ async function run_action() {
   const ssmValue = core.getInput("ssm-value");
   const ssmType = core.getInput("ssm-value-type");
   const prefix = core.getInput("prefix");
+  const keyName = core.getInput("key-name");
   const decryption = core.getInput("decryption") === "true";
   const nullable = core.getInput("nullable") === "true";
+  const jsonAsString = core.getInput("json-as-string") === "true";
   const region = process.env.AWS_DEFAULT_REGION;
 
   try {
     const paramValue = await ssm.getParameter(ssmPath, decryption, region);
-    jsonOrString(paramValue, core, prefix, ssmPath);
+    jsonOrString(paramValue, core, prefix, ssmPath, jsonAsString, keyName);
   } catch (error) {
     core.debug(`Error name: ${error.name}`);
     if (error.name === "ParameterNotFound") {
       core.debug(`could not find parameter, attemping to create parameter`);
       ssm.createSsmValue(ssmPath, region, ssmValue, ssmType, core, nullable);
-      jsonOrString(ssmValue, core, prefix, ssmPath);
+      jsonOrString(ssmValue, core, prefix, ssmPath, jsonAsString, keyName);
       return;
     }
   }
@@ -43,21 +45,32 @@ function setEnvironmentVar(key, value) {
   execSync(cmdString, { stdio: "inherit" });
 }
 
-function jsonOrString(paramValue, core, prefix, ssmPath) {
+function jsonOrString(
+  paramValue,
+  core,
+  prefix,
+  ssmPath,
+  jsonAsString,
+  keyName
+) {
   const parsedValue = parseValue(paramValue);
+  if (jsonAsString && typeof parsedValue === "object") {
+    return setEnvironmentVar(keyName, paramValue);
+  }
   if (typeof parsedValue === "object") {
     core.debug(`parsedValue: ${JSON.stringify(parsedValue)}`);
     // Assume basic JSON structure
     for (const key in parsedValue) {
       setEnvironmentVar(prefix + key, parsedValue[key]);
     }
+    return;
   } else {
     core.debug(`parsedValue: ${parsedValue}`);
     // Set environment variable with ssmPath name as the env variable
     const split = ssmPath.split("/");
     const envVarName = prefix + split[split.length - 1];
     core.debug(`Using prefix + end of ssmPath for env var name: ${envVarName}`);
-    setEnvironmentVar(envVarName, parsedValue);
+    return setEnvironmentVar(envVarName, parsedValue);
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -5,12 +5,12 @@ const execSync = require("child_process").execSync;
 
 async function run_action() {
   const ssmPath = core.getInput("ssm-path", { required: true });
-  const ssmValue = core.getInput("ssm-value", { required: false });
-  const ssmType = core.getInput("ssm-value-type", { required: false });
+  const ssmValue = core.getInput("ssm-value");
+  const ssmType = core.getInput("ssm-value-type");
   const keyName = core.getInput("key-name");
-  const region = process.env.AWS_DEFAULT_REGION;
   const decryption = core.getInput("decryption") === "true";
   const nullable = core.getInput("nullable") === "true";
+  const region = process.env.AWS_DEFAULT_REGION;
 
   try {
     const paramValue = await ssm.getParameter(ssmPath, decryption, region);

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ async function run_action() {
   const ssmPath = core.getInput("ssm-path", { required: true });
   const ssmValue = core.getInput("ssm-value");
   const ssmType = core.getInput("ssm-value-type");
-  const keyName = core.getInput("key-name");
+  const prefix = core.getInput("prefix");
   const decryption = core.getInput("decryption") === "true";
   const nullable = core.getInput("nullable") === "true";
   const region = process.env.AWS_DEFAULT_REGION;
@@ -19,15 +19,15 @@ async function run_action() {
       core.debug(`parsedValue: ${JSON.stringify(parsedValue)}`);
       // Assume basic JSON structure
       for (const key in parsedValue) {
-        setEnvironmentVar(keyName + key, parsedValue[key]);
+        setEnvironmentVar(prefix + key, parsedValue[key]);
       }
     } else {
       core.debug(`parsedValue: ${parsedValue}`);
       // Set environment variable with ssmPath name as the env variable
       const split = ssmPath.split("/");
-      const envVarName = keyName + split[split.length - 1];
+      const envVarName = prefix + split[split.length - 1];
       core.debug(
-        `Using keyName + end of ssmPath for env var name: ${envVarName}`
+        `Using prefix + end of ssmPath for env var name: ${envVarName}`
       );
       setEnvironmentVar(envVarName, parsedValue);
     }

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ async function run_action() {
     if (typeof parsedValue === "object") {
       core.debug(`parsedValue: ${JSON.stringify(parsedValue)}`);
       // Assume basic JSON structure
-      for (var key in parsedValue) {
+      for (const key in parsedValue) {
         setEnvironmentVar(keyName + key, parsedValue[key]);
       }
     } else {

--- a/index.js
+++ b/index.js
@@ -23,6 +23,8 @@ async function run_action() {
       ssm.createSsmValue(ssmPath, region, ssmValue, ssmType, core, nullable);
       jsonOrString(ssmValue, core, prefix, ssmPath, jsonAsString);
       return;
+    } else {
+      core.debug(`could not find parameter: ${error.message}`);
     }
   }
 }
@@ -49,7 +51,7 @@ function jsonOrString(paramValue, core, prefix, ssmPath, jsonAsString) {
   if (jsonAsString) {
     const envVarName = prefix + split[split.length - 1];
     core.debug(`Using prefix + end of ssmPath for env var name: ${envVarName}`);
-    return setEnvironmentVar(envVarName, `${paramValue}`);
+    return setEnvironmentVar(envVarName, paramValue);
   }
   if (typeof parsedValue === "object") {
     core.debug(`parsedValue: ${JSON.stringify(parsedValue)}`);

--- a/index.js
+++ b/index.js
@@ -1,57 +1,65 @@
-const core = require('@actions/core');
-const ssm = require('./ssm-helper');
+const core = require("@actions/core");
+const ssm = require("./ssm-helper");
 
-const execSync = require('child_process').execSync;
+const execSync = require("child_process").execSync;
 
 async function run_action() {
-    const ssmPath = core.getInput('ssm-path', { required: true });
-    const prefix = core.getInput('prefix');
-    const region = process.env.AWS_DEFAULT_REGION;
-    const decryption = core.getInput('decryption') === 'true';
-    const nullable = core.getInput('nullable') === 'true';
+  const ssmPath = core.getInput("ssm-path", { required: true });
+  const ssmValue = core.getInput("ssm-value", { required: false });
+  const ssmType = core.getInput("ssm-value-type", { required: false });
+  const keyName = core.getInput("key-name");
+  const region = process.env.AWS_DEFAULT_REGION;
+  const decryption = core.getInput("decryption") === "true";
+  const nullable = core.getInput("nullable") === "true";
 
-    try {
-
-        paramValue = await ssm.getParameter(ssmPath, decryption, region);
-        parsedValue = parseValue(paramValue);
-        if (typeof(parsedValue) === 'object') {
-            core.debug(`parsedValue: ${JSON.stringify(parsedValue)}`);
-            // Assume basic JSON structure
-            for (var key in parsedValue) {
-                setEnvironmentVar(prefix + key, parsedValue[key])
-            }
-        } else {
-            core.debug(`parsedValue: ${parsedValue}`);
-            // Set environment variable with ssmPath name as the env variable
-            var split = ssmPath.split('/');
-            var envVarName = prefix + split[split.length - 1];
-            core.debug(`Using prefix + end of ssmPath for env var name: ${envVarName}`);
-            setEnvironmentVar(envVarName, parsedValue);
-        }
-        
-    } catch (error) {
-        if(!nullable) {
-            core.setFailed(error.message);
-        } else {
-            core.debug(`could not find parameter: ${error.message}`);
-        }
+  try {
+    const paramValue = await ssm.getParameter(ssmPath, decryption, region);
+    const parsedValue = parseValue(paramValue);
+    if (typeof parsedValue === "object") {
+      core.debug(`parsedValue: ${JSON.stringify(parsedValue)}`);
+      // Assume basic JSON structure
+      for (var key in parsedValue) {
+        setEnvironmentVar(keyName + key, parsedValue[key]);
+      }
+    } else {
+      core.debug(`parsedValue: ${parsedValue}`);
+      // Set environment variable with ssmPath name as the env variable
+      const split = ssmPath.split("/");
+      const envVarName = keyName + split[split.length - 1];
+      core.debug(
+        `Using keyName + end of ssmPath for env var name: ${envVarName}`
+      );
+      setEnvironmentVar(envVarName, parsedValue);
     }
+  } catch (error) {
+    if (error instanceof ParameterNotFound) {
+      core.debug(`could not find parameter, attemping to create parameter`);
+      createSsmValue(ssmPath, region, ssmValue, ssmType);
+      run_action(ssmPath, decryption, region);
+    }
+    if (!nullable) {
+      core.setFailed(error.message);
+    } else {
+      core.debug(`could not find parameter: ${error.message}`);
+    }
+  }
 }
 
-
 function parseValue(val) {
-    try {
-        return JSON.parse(val);
-    } catch (error) {
-        core.debug('JSON parse failed - assuming parameter is to be taken as a string literal');
-        return val;
-    }
+  try {
+    return JSON.parse(val);
+  } catch (error) {
+    core.debug(
+      "JSON parse failed - assuming parameter is to be taken as a string literal"
+    );
+    return val;
+  }
 }
 
 function setEnvironmentVar(key, value) {
-    cmdString = `echo "${key}=${value}" >> $GITHUB_ENV`;
-    core.debug(`Running cmd: ${cmdString}`);
-    execSync(cmdString, {stdio: 'inherit'});
+  cmdString = `echo "${key}=${value}" >> $GITHUB_ENV`;
+  core.debug(`Running cmd: ${cmdString}`);
+  execSync(cmdString, { stdio: "inherit" });
 }
 
 run_action();

--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ function jsonOrString(
 ) {
   const parsedValue = parseValue(paramValue);
   if (jsonAsString && typeof parsedValue === "object") {
-    return setEnvironmentVar(keyName, paramValue);
+    return setEnvironmentVar(keyName, `${paramValue}`);
   }
   if (typeof parsedValue === "object") {
     core.debug(`parsedValue: ${JSON.stringify(parsedValue)}`);

--- a/ssm-helper.js
+++ b/ssm-helper.js
@@ -36,7 +36,7 @@ const createSsmValue = async (
       core.debug(`Setting the KeyId to ${keyId}`);
       params["KeyId"] = keyId;
     }
-    const result = await ssm.putParameter(params);
+    const result = await ssm.putParameter(params).promise();
     core.debug(
       `Parameter details Version [${result.Version}] Tier [${result.Tier}]`
     );

--- a/ssm-helper.js
+++ b/ssm-helper.js
@@ -1,15 +1,42 @@
-const AWS = require('aws-sdk');
+const AWS = require("aws-sdk");
 
 const getParameter = async (ssmPath, decryption, region) => {
-    AWS.config.update({region: region});
-    const ssm = new AWS.SSM();
-    const params =
-    {
-        Name: ssmPath,
-        WithDecryption: decryption
-    };
-    const result = await ssm.getParameter(params).promise();
-    return result.Parameter.Value;
-}
+  AWS.config.update({ region: region });
+  const ssm = new AWS.SSM();
+  const params = {
+    Name: ssmPath,
+    WithDecryption: decryption,
+  };
+  const result = await ssm.getParameter(params).promise();
+  return result.Parameter.Value;
+};
 
-module.exports = {getParameter};
+const createSsmValue = async (ssmPath, region, ssmValue, ssmType) => {
+  try {
+    core.info(`Storing Variable in path [${ssmPath}]`);
+    // Load the AWS Region to use in SSM
+    core.debug(`Setting aws-region [${region}]`);
+    AWS.config.update({ region: region });
+    const ssm = new AWS.SSM();
+    const params = {
+      Name: ssmPath,
+      Value: ssmValue,
+      Type: ssmType,
+      Overwrite: false,
+    };
+    const keyId = core.getInput("ssm-kms-key-id");
+    if (params["Type"] === "SecureString" && keyId !== "") {
+      core.debug(`Setting the KeyId to ${keyId}`);
+      params["KeyId"] = keyId;
+    }
+    const result = await ssm.putParameter(params);
+    core.debug(
+      `Parameter details Version [${result.Version}] Tier [${result.Tier}]`
+    );
+    core.info(`Successfully Stored parameter in path [${ssmPath}]`);
+  } catch (error) {
+    core.setFailed(error.message);
+  }
+};
+
+module.exports = { getParameter, createSsmValue };

--- a/ssm-helper.js
+++ b/ssm-helper.js
@@ -11,7 +11,14 @@ const getParameter = async (ssmPath, decryption, region) => {
   return result.Parameter.Value;
 };
 
-const createSsmValue = async (ssmPath, region, ssmValue, ssmType) => {
+const createSsmValue = async (
+  ssmPath,
+  region,
+  ssmValue,
+  ssmType,
+  core,
+  nullable
+) => {
   try {
     core.info(`Storing Variable in path [${ssmPath}]`);
     // Load the AWS Region to use in SSM
@@ -35,7 +42,11 @@ const createSsmValue = async (ssmPath, region, ssmValue, ssmType) => {
     );
     core.info(`Successfully Stored parameter in path [${ssmPath}]`);
   } catch (error) {
-    core.setFailed(error.message);
+    if (!nullable) {
+      core.setFailed(error.message);
+    } else {
+      core.debug(`could not find parameter: ${error.message}`);
+    }
   }
 };
 


### PR DESCRIPTION
Adapts [this github action](https://github.com/dwardu89/aws-ssm-parameter-store) to only write a new parameter store value when the parameter store key doesn't exist. This avoids a key issue with the action from our use case, where a new value would either overwrite a previous value or fail because a value already exists. It still needs to be tested, looking for the best way to do so.